### PR TITLE
Simplify Ruff version management in CI

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,7 +1,7 @@
 {
   "template": "http://github.com/allenporter/cookiecutter-home-assistant-custom-component",
   "commit": "33a4ae597bbe3c20942be62b6044825cebb99f08",
-  "checkout": "fix-ruff-action-ci",
+  "checkout": null,
   "context": {
     "cookiecutter": {
       "full_name": "Allen Porter",

--- a/.cruft.json
+++ b/.cruft.json
@@ -1,7 +1,7 @@
 {
   "template": "http://github.com/allenporter/cookiecutter-home-assistant-custom-component",
-  "commit": "f36c3e8b0e97ea0f01e525e0607f8b4027196f1d",
-  "checkout": null,
+  "commit": "33a4ae597bbe3c20942be62b6044825cebb99f08",
+  "checkout": "fix-ruff-action-ci",
   "context": {
     "cookiecutter": {
       "full_name": "Allen Porter",

--- a/.github/workflows/cruft.yaml
+++ b/.github/workflows/cruft.yaml
@@ -4,6 +4,7 @@ permissions:
   contents: write
   pull-requests: write
   actions: write
+  workflows: write
 on:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,6 @@ jobs:
       - name: Validate Renovate configuration
         run: |
           npx --package=renovate@38 -- renovate-config-validator .github/renovate.json5
-      - uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
       - uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
         with:
           check_hidden: false


### PR DESCRIPTION
Apply template updates from cookiecutter-home-assistant-custom-component to remove the standalone astral-sh/ruff-action step, resolving mismatch failures in CI.