### PR TITLE
Pin renovate CLI in lint workflow and add Renovate customManager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,15 @@
       assignees: [],
     },
   ],
+  customManagers: [
+    {
+      customType: "regex",
+      fileMatch: ["^\\.github/workflows/lint\\.yaml$"],
+      matchStrings: ["npx --package=renovate@(?<currentValue>[^\\s]+)"],
+      depNameTemplate: "renovate",
+      datasourceTemplate: "npm",
+    },
+  ],
   pip_requirements: {
     fileMatch: ["^requirements_dev\\.txt$"],
   },

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Validate Renovate configuration
         run: |
-          npx --package=renovate -- renovate-config-validator .github/renovate.json5
+          npx --package=renovate@43.280.5 -- renovate-config-validator .github/renovate.json5
       - uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579 # v2.2
         with:
           check_hidden: false


### PR DESCRIPTION
### Summary
Pins the `renovate` package in `.github/workflows/lint.yaml` to an exact version (`43.280.5`) and adds a `customManagers` regex configuration in `.github/renovate.json5` so Renovate Bot automatically tracks and updates the pinned version string via PRs.

### Rationale
- **Supply Chain Security**: Avoids executing unpinned dynamic `npx` packages in CI runners.
- **Automated Upgrades**: Ensures Renovate Bot automatically handles updating the validator package version via standard PRs.